### PR TITLE
linuxday 2022

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -4,9 +4,9 @@
 specfile_path: python-teamcity-messages.spec
 
 # add or remove files that should be synced
-synced_files:
-    - python-teamcity-messages.spec
-    - .packit.yaml
+files_to_sync:
+  - python-teamcity-messages.spec
+  - .packit.yaml
 
 # name in upstream package repository or registry (e.g. in PyPI)
 upstream_package_name: teamcity-messages
@@ -20,5 +20,22 @@ upstream_tag_template: v{version}
 jobs:
 - job: copr_build
   trigger: commit
-  metadata:
-    targets: fedora-stable
+  targets: 
+  - fedora-stable
+  - fedora-development
+- job: propose_downstream
+  trigger: release
+  dist_git_branches:
+  - fedora-stable
+  - fedora-development
+# downstream automation:
+- job: koji_build
+  trigger: commit
+  allowed_pr_authors: ["packit"]
+  dist_git_branches:
+  - fedora-stable
+  - fedora-development
+- job: bodhi_update
+  trigger: commit
+  dist_git_branches:
+    - fedora-stable # branched version, rawhide updates are created automatically

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -40,6 +40,7 @@ project {
     buildType(Python39linux)
     buildType(Python310linux)
     buildType(Pypy2linux)
+    buildType(Pypy37linux)
     buildType(Pypy3linux)
 
     template(LinuxTeamcityMessagesTemplate)
@@ -171,6 +172,7 @@ object Build : BuildType({
         snapshot(Python39linux) {}
         snapshot(Python310linux) {}
         snapshot(Pypy2linux) {}
+        snapshot(Pypy37linux) {}
         snapshot(Pypy3linux) {}
     }
 
@@ -266,6 +268,17 @@ object Pypy3linux : BuildType({
     params {
         param("PYTHON_EXECUTABLE", "pypy")
         param("PYTHON_DOCKER_IMAGE", "pypy:3")
+    }
+
+})
+
+object Pypy37linux : BuildType({
+    templates(LinuxTeamcityMessagesTemplate)
+    name = "Pypy 3.7 (Linux)"
+
+    params {
+        param("PYTHON_EXECUTABLE", "pypy")
+        param("PYTHON_DOCKER_IMAGE", "pypy:3.7")
     }
 
 })

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -33,10 +33,12 @@ project {
 
     buildType(Build)
     buildType(Python39windows)
+    buildType(Python310windows)
     buildType(Python27linux)
     buildType(Python37linux)
     buildType(Python38linux)
     buildType(Python39linux)
+    buildType(Python310linux)
     buildType(Pypy2linux)
     buildType(Pypy3linux)
 
@@ -162,10 +164,12 @@ object Build : BuildType({
 
     dependencies {
         snapshot(Python39windows) {}
+        snapshot(Python310windows) {}
         snapshot(Python27linux) {}
         snapshot(Python37linux) {}
         snapshot(Python38linux) {}
         snapshot(Python39linux) {}
+        snapshot(Python310linux) {}
         snapshot(Pypy2linux) {}
         snapshot(Pypy3linux) {}
     }
@@ -179,6 +183,15 @@ object Python39windows : BuildType({
 
     params {
         param("PYTHON_DOCKER_IMAGE", "python:3.9")
+    }
+})
+
+object Python310windows : BuildType({
+    templates(WindowsTeamcityMessagesTemplate)
+    name = "Python 3.10 (Windows)"
+
+    params {
+        param("PYTHON_DOCKER_IMAGE", "python:3.10")
     }
 })
 
@@ -222,6 +235,16 @@ object Python39linux : BuildType({
     params {
         param("PYTHON_EXECUTABLE", "python")
         param("PYTHON_DOCKER_IMAGE", "python:3.9")
+    }
+})
+
+object Python310linux : BuildType({
+    templates(LinuxTeamcityMessagesTemplate)
+    name = "Python 3.10 (Linux)"
+
+    params {
+        param("PYTHON_EXECUTABLE", "python")
+        param("PYTHON_DOCKER_IMAGE", "python:3.10")
     }
 })
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -155,7 +155,7 @@ object Build : BuildType({
             publisher = github {
                 githubUrl = "https://api.github.com"
                 authType = personalToken {
-                    token = "credentialsJSON:d376fdcd-064c-4098-92c0-1c4afab57d88"
+                    token = "credentialsJSON:629f6262-fd6d-4ee3-845d-5ac1be62d64e"
                 }
             }
         }

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -32,7 +32,6 @@ version = "2021.2"
 project {
 
     buildType(Build)
-    buildType(Python39windows)
     buildType(Python310windows)
     buildType(Python27linux)
     buildType(Python37linux)
@@ -164,7 +163,6 @@ object Build : BuildType({
 
 
     dependencies {
-        snapshot(Python39windows) {}
         snapshot(Python310windows) {}
         snapshot(Python27linux) {}
         snapshot(Python37linux) {}
@@ -178,15 +176,6 @@ object Build : BuildType({
 
 })
 
-
-object Python39windows : BuildType({
-    templates(WindowsTeamcityMessagesTemplate)
-    name = "Python 3.9 (Windows)"
-
-    params {
-        param("PYTHON_DOCKER_IMAGE", "python:3.9")
-    }
-})
 
 object Python310windows : BuildType({
     templates(WindowsTeamcityMessagesTemplate)

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,9 @@
 Change Log
 ----------
 
+Version 1.32 Tue Sep 27 2022
+  - flake8: fix flake8 >= 5 by @itsb #266 #264
+
 Version 1.31 Tue Feb 22 2022
   - python: supported Python 3.10
   - escape unencodable messages by @kri-k #261

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,10 @@
 Change Log
 ----------
 
+Version 1.31 Tue Feb 22 2022
+  - python: supported Python 3.10
+  - escape unencodable messages by @kri-k #261
+
 Version 1.30 Fri Dec 17 2021
   - support pylint >= 2.12 by @Tirzono #259
   - pytest: fix assert diffs by @ikonst #247

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,10 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-virtualenv_version = 'virtualenv==20.7.2'
+if sys.version_info < (3, 0):
+    virtualenv_version = 'virtualenv==20.7.2'
+else:
+    virtualenv_version = 'virtualenv==20.16.5'
 if sys.version_info < (3, 7):
     # fix compatible version for slowly obsoleting versions
     tests_require = ['pytest==4.6.9', virtualenv_version]

--- a/setup.py
+++ b/setup.py
@@ -110,9 +110,6 @@ setup(
             'pytest-teamcity = teamcity.pytest_plugin',
         ],
 
-        'flake8.extension': [
-            'teamcity-messages = teamcity.flake8_plugin:TeamcityReport',
-        ],
         'flake8.report': [
             'teamcity-messages = teamcity.flake8_plugin:TeamcityReport',
         ]

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Software Development :: Testing'
     ],
     url="https://github.com/JetBrains/teamcity-messages",

--- a/teamcity/__init__.py
+++ b/teamcity/__init__.py
@@ -3,7 +3,7 @@ import os
 
 __all__ = ['is_running_under_teamcity']
 
-__version__ = "1.31"
+__version__ = "1.32"
 
 teamcity_presence_env_var = "TEAMCITY_VERSION"
 

--- a/teamcity/__init__.py
+++ b/teamcity/__init__.py
@@ -3,7 +3,7 @@ import os
 
 __all__ = ['is_running_under_teamcity']
 
-__version__ = "1.30"
+__version__ = "1.31"
 
 teamcity_presence_env_var = "TEAMCITY_VERSION"
 

--- a/teamcity/messages.py
+++ b/teamcity/messages.py
@@ -65,7 +65,7 @@ class TeamcityServiceMessages(object):
 
     def encode(self, value):
         if self.encoding and isinstance(value, text_type):
-            value = value.encode(self.encoding)
+            value = value.encode(self.encoding, errors='backslashreplace')
         return value
 
     def decode(self, value):

--- a/tests/integration-tests/django1_integration_test.py
+++ b/tests/integration-tests/django1_integration_test.py
@@ -14,6 +14,8 @@ def venv(request):
         pytest.skip("Django 1.11.17 requires Python 2.7 or 3.4+")
     if (3, 0) <= sys.version_info < (3, 4):
         pytest.skip("Django 1.11.17 requires Python 2.7 or 3.4+")
+    if sys.version_info >= (3, 10):
+        pytest.skip("Django 1.11.17 requires Python < 3.10")
     return virtual_environments.prepare_virtualenv([request.param])
 
 

--- a/tests/integration-tests/nose_integration_test.py
+++ b/tests/integration-tests/nose_integration_test.py
@@ -12,6 +12,8 @@ from test_util import run_command, get_teamcity_messages_root
 
 @pytest.fixture(scope='module', params=["nose==1.3.7"])  # Nose is dead, support only latest version
 def venv(request):
+    if sys.version_info >= (3, 10):
+        pytest.skip("Nose is not working with Python 3.10+")
     """
     Prepares a virtual environment for nose.
     :rtype : virtual_environments.VirtualEnvDescription

--- a/tests/integration-tests/nose_integration_test.py
+++ b/tests/integration-tests/nose_integration_test.py
@@ -12,12 +12,12 @@ from test_util import run_command, get_teamcity_messages_root
 
 @pytest.fixture(scope='module', params=["nose==1.3.7"])  # Nose is dead, support only latest version
 def venv(request):
-    if sys.version_info >= (3, 10):
-        pytest.skip("Nose is not working with Python 3.10+")
     """
     Prepares a virtual environment for nose.
     :rtype : virtual_environments.VirtualEnvDescription
     """
+    if sys.version_info >= (3, 8):
+        pytest.skip("nose is outdated and doesn't support 3.8")
     return virtual_environments.prepare_virtualenv([request.param])
 
 
@@ -486,8 +486,6 @@ def test_nose_parameterized(venv):
 
 
 def run(venv, file, clazz=None, test=None, print_output=True, options=""):
-    if sys.version_info > (3, 8):
-        pytest.skip("nose is outdated and doesn't support 3.8")
     if clazz:
         clazz_arg = ":" + clazz
     else:

--- a/tests/integration-tests/pylint_integration_test.py
+++ b/tests/integration-tests/pylint_integration_test.py
@@ -9,7 +9,7 @@ from test_util import run_command
 if sys.version_info < (3, ):
     pylint_versions = ['==1.9.5']
 else:
-    pylint_versions = ['==2.4.4', '==2.5.3', '']
+    pylint_versions = ['==2.4.4', '==2.5.3', '==2.12.2', '==2.14.5', '']
 
 
 @pytest.fixture(scope='module', params=['pylint' + version for version in pylint_versions], ids=str)
@@ -30,6 +30,11 @@ def venv(request):
 def test_sample(venv):
     filename = 'tests/guinea-pigs/pylint/sample.py'
     output = run(venv, filename)
+    negative_score_possible = ['==1.9.5', '==2.4.4', '==2.5.3', '==2.12.2']
+    expected_score = '0'
+    for negative_score_possible_version in negative_score_possible:
+        if 'pylint' + negative_score_possible_version in venv.packages:
+            expected_score = '-18.0'
     assert_service_messages(
         output,
         [
@@ -61,7 +66,7 @@ def test_sample(venv):
             ServiceMessage('inspection', dict(SEVERITY='WARNING', file='tests/guinea-pigs/pylint/sample.py', line='7',
                                               message='Unused variable |\'seven|\'', typeId='W0612')),
 
-            ServiceMessage('buildStatisticValue', dict(key='PyLintScore', value='-18.0')),
+            ServiceMessage('buildStatisticValue', dict(key='PyLintScore', value=expected_score))
         ]
     )
 

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -88,11 +88,21 @@ if (sys.version_info[0] == 2 and sys.version_info >= (2, 7)) or (sys.version_inf
 
         assert ms[2].params["details"].find("Unused import sys") > 0
 
-    def test_pytest_flake8(venv):
+    def test_pytest_flake8_v1_0(venv):
         # Use flake8 < 4 as there is an issue in pytest-flake8 package:
         # https://github.com/tholo/pytest-flake8/issues/81
-        venv_with_pylint = virtual_environments.prepare_virtualenv(venv.packages + ("pytest-flake8",) + ("flake8==3.9.2",))
+        venv_with_pylint = virtual_environments.prepare_virtualenv(venv.packages + ("pytest-flake8==1.0.7",) + ("flake8==3.9.2",))
+        internal_test_pytest_flake8(venv_with_pylint, "tests.guinea-pigs.pytest.{}.FLAKE8")
 
+
+    def test_pytest_flake8_v1_1(venv):
+        # Use flake8 < 4 as there is an issue in pytest-flake8 package:
+        # https://github.com/tholo/pytest-flake8/issues/87
+        venv_with_pylint = virtual_environments.prepare_virtualenv(venv.packages + ("pytest-flake8",) + ("flake8==4.0.1",))
+        internal_test_pytest_flake8(venv_with_pylint, "tests.guinea-pigs.pytest.{}.flake-8.FLAKE8")
+
+
+    def internal_test_pytest_flake8(venv_with_pylint, flake8_test_name_format):
         file_names = ['./flake8_test1.py', './flake8_test2.py']
         output = run(venv_with_pylint, file_names, options="--flake8")
         file_paths = [os.path.realpath(os.path.join('tests', 'guinea-pigs', 'pytest', file_name))
@@ -100,7 +110,7 @@ if (sys.version_info[0] == 2 and sys.version_info >= (2, 7)) or (sys.version_inf
         expected = [ServiceMessage('testCount', {'count': "4"})]
         for file_path in file_paths:
             test_base, _ = os.path.splitext(os.path.basename(file_path))
-            flake8_test_name = "tests.guinea-pigs.pytest.{}.FLAKE8".format(test_base)
+            flake8_test_name = flake8_test_name_format.format(test_base)
             pytest_name = "tests.guinea-pigs.pytest.{}.test_ok".format(test_base)
             expected.extend([
                 ServiceMessage('testStarted', {'name': flake8_test_name}),
@@ -119,6 +129,7 @@ if (sys.version_info[0] == 2 and sys.version_info >= (2, 7)) or (sys.version_inf
             ])
         ms = assert_service_messages(output, expected)
         assert ms[2].params["details"].find(test_message.replace('|', '|||')) > 0
+
 
 
 def test_hierarchy(venv):

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -95,8 +95,9 @@ if (sys.version_info[0] == 2 and sys.version_info >= (2, 7)) or (sys.version_inf
         internal_test_pytest_flake8(venv_with_pylint, "tests.guinea-pigs.pytest.{}.FLAKE8")
 
 
+    @pytest.mark.skipif("sys.version_info < (3, 7)", reason="requires Python 3.7+")
     def test_pytest_flake8_v1_1(venv):
-        # Use flake8 < 4 as there is an issue in pytest-flake8 package:
+        # Use flake8 < 5 as there is an issue in pytest-flake8 package:
         # https://github.com/tholo/pytest-flake8/issues/87
         venv_with_pylint = virtual_environments.prepare_virtualenv(venv.packages + ("pytest-flake8",) + ("flake8==4.0.1",))
         internal_test_pytest_flake8(venv_with_pylint, "tests.guinea-pigs.pytest.{}.flake-8.FLAKE8")

--- a/tests/integration-tests/pytest_integration_test.py
+++ b/tests/integration-tests/pytest_integration_test.py
@@ -171,9 +171,9 @@ def test_custom_test_items(venv):
 
 if sys.version_info >= (2, 6):
     @pytest.mark.parametrize("coverage_version, pytest_cov_version", [
-        ("==4.4.2", "==2.7.1"),
-        ("==4.5.4", "==2.7.1"),
-        ("==5.0.1", "==2.7.1"),
+        ("==4.4.2", "==2.11.1"),
+        ("==4.5.4", "==2.11.1"),
+        ("==5.0.1", "==2.11.1"),
         # latest
         ("", ""),
     ])

--- a/tests/integration-tests/virtual_environments.py
+++ b/tests/integration-tests/virtual_environments.py
@@ -55,7 +55,7 @@ def prepare_virtualenv(packages=()):
     vpython = os.path.join(vbin, 'python' + get_exe_suffix())
     vpip = os.path.join(vbin, 'pip' + get_exe_suffix())
 
-    vpip_install = [vpip, "install", "--force-reinstall"]
+    vpip_install = [vpython, "-m", "pip", "install", "--force-reinstall"]
     if (2, 5) <= sys.version_info < (2, 6):
         vpip_install.append("--insecure")
 

--- a/tests/integration-tests/virtual_environments.py
+++ b/tests/integration-tests/virtual_environments.py
@@ -55,7 +55,7 @@ def prepare_virtualenv(packages=()):
     vpython = os.path.join(vbin, 'python' + get_exe_suffix())
     vpip = os.path.join(vbin, 'pip' + get_exe_suffix())
 
-    vpip_install = [vpip, "install"]
+    vpip_install = [vpip, "install", "--force-reinstall"]
     if (2, 5) <= sys.version_info < (2, 6):
         vpip_install.append("--insecure")
 


### PR DESCRIPTION
- Escape unencodable messages
- Add test builds for Python 3.10
- Drop tests for Python 3.10 for outdated django and nose
- Add test builds for Pypy 3.7
- Fix tests: force reinstall packages in tests
- Fix tests: skip nose test for Python 3.8+
- Fix tests: update pytest-cov for newer setuptools
- Fix tests: run pip from python not directly
- 1.31
- flake8 formatter, not extension
- Update commit status publisher token
- Remove Python 3.9 Windows tests as there are no compatible docker container
- Update virtualenv to 20.16.5 (#267)
- Fix tests for pylint > 2.13 as pylint now is not reporting negative score values
- Fix tests for pytest-flake8 new 1.1 version
- Skip test for pytest-flake8 1.1 for unsupported Python versions
- 1.32
- Create a SPEC file
- Enable packit
- Fix downstream project name
- Add propose_downstream job
